### PR TITLE
Create Maven-based SemaforoJavaFX project with game mode

### DIFF
--- a/SemaforoJavaFX/README.md
+++ b/SemaforoJavaFX/README.md
@@ -1,0 +1,61 @@
+# Simulador de Semáforo en JavaFX
+
+Aplicación JavaFX que simula un semáforo con una línea de tiempo animada, incluye un modo de juego de reacción y reglas declarativas de programación lógica para evaluar acciones según la luz.
+
+## Requisitos
+- JDK 21+ (probado con la configuración del `pom.xml`).
+- Maven 3.9+
+- Dependencias JavaFX gestionadas por Maven (`javafx-controls` y `javafx-fxml`).
+
+## Estructura del proyecto
+- `src/main/java/com/example/semaforo/TrafficLightApp.java`: arranque JavaFX con interfaz moderna, controles, timeline y paneles.
+- `src/main/java/com/example/semaforo/TrafficLightLogic.java`: lógica funcional del cambio de estado.
+- `src/main/java/com/example/semaforo/Light.java`: enum de estados RED, GREEN, YELLOW.
+- `src/main/java/com/example/semaforo/GameLogic.java`: lógica del modo juego y función pura de puntaje.
+- `src/main/java/com/example/semaforo/LightRules.java`: reglas declarativas estilo programación lógica.
+- `src/main/resources/style.css`: estilos oscuros para la interfaz.
+
+## Compilar y ejecutar con Maven
+Desde la carpeta `SemaforoJavaFX`:
+
+```bash
+mvn clean package
+mvn javafx:run
+```
+
+El plugin `javafx-maven-plugin` usa la clase principal `com.example.semaforo.TrafficLightApp`.
+
+## Uso de la aplicación
+1. **Simulación del semáforo**
+   - Pulsa **Iniciar** para arrancar el `Timeline`. Cambia de RED → GREEN → YELLOW en bucle.
+   - Ajusta el **Slider** para definir los segundos por estado; el `Timeline` se reconstruye con la nueva duración.
+   - Botones **Pausar** y **Reanudar** controlan la animación.
+   - El panel oscuro muestra las tres luces en un contenedor que simula el armazón del semáforo.
+
+2. **Modo juego (“¡YA!”)**
+   - Cuando creas que el semáforo está en verde, pulsa el botón **¡YA!**.
+   - `GameLogic` guarda la marca de tiempo del último cambio a verde y calcula la diferencia con el clic.
+   - La función pura `calcularPuntaje(long diferenciaMs)` reparte más puntos cuanto menor sea la reacción.
+   - Se muestran aciertos, errores y puntaje acumulado en vivo.
+
+3. **Programación lógica (LightRules)**
+   - Ingresa una acción (por ejemplo, `avanzar` o `detenerse`) y pulsa **Evaluar acción**.
+   - `LightRules` consulta reglas estáticas tipo mapa (rojo/avanzar → “Infracción”, verde/avanzar → “Permitido”, amarillo/avanzar → “Precaución”).
+   - El resultado se muestra en la interfaz junto con el estado actual del semáforo.
+
+## Dónde se usa programación funcional
+- `TrafficLightLogic#nextState` está implementado con una `UnaryOperator<Light>` que, dada una luz, devuelve siempre la siguiente. Es pura porque no depende de estado global ni produce efectos secundarios.
+- `GameLogic#calcularPuntaje` es otra función pura: se basa únicamente en el tiempo de reacción que recibe como parámetro.
+
+## Dónde se usa programación lógica
+- `LightRules` almacena reglas declarativas en mapas inmutables para evaluar combinaciones de luz y acción. `evaluarAccion` retorna la consecuencia (“Permitido”, “Infracción” o “Precaución”) siguiendo esas reglas.
+
+## Timeline y ciclo de luces
+- El `Timeline` tiene un `KeyFrame` que se dispara cada *n* segundos (valor del slider) y avanza el estado RED → GREEN → YELLOW → RED usando `TrafficLightLogic`.
+- La reconstrucción del `Timeline` al mover el slider permite ajustar la duración sin reiniciar la aplicación.
+
+## Capturas
+Si tienes acceso a un entorno gráfico, ejecuta la aplicación y toma una captura de la ventana principal. (No se adjunta imagen aquí por limitaciones del entorno.)
+
+## Créditos
+Creado para demostrar combinación de JavaFX, programación funcional y lógica.

--- a/SemaforoJavaFX/pom.xml
+++ b/SemaforoJavaFX/pom.xml
@@ -1,0 +1,50 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>semaforo-javafx</artifactId>
+    <version>1.0.0</version>
+    <name>SemaforoJavaFX</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <javafx.version>21.0.4</javafx.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-controls</artifactId>
+            <version>${javafx.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-fxml</artifactId>
+            <version>${javafx.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.12.1</version>
+                <configuration>
+                    <release>${maven.compiler.source}</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.openjfx</groupId>
+                <artifactId>javafx-maven-plugin</artifactId>
+                <version>${javafx.version}</version>
+                <configuration>
+                    <mainClass>com.example.semaforo.TrafficLightApp</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/SemaforoJavaFX/src/main/java/com/example/semaforo/GameLogic.java
+++ b/SemaforoJavaFX/src/main/java/com/example/semaforo/GameLogic.java
@@ -1,0 +1,65 @@
+package com.example.semaforo;
+
+/**
+ * Lógica del modo de juego de reacción.
+ */
+public class GameLogic {
+
+    private int aciertos;
+    private int errores;
+    private long puntajeTotal;
+    private Long ultimoVerdeMs;
+
+    public void reset() {
+        aciertos = 0;
+        errores = 0;
+        puntajeTotal = 0;
+        ultimoVerdeMs = null;
+    }
+
+    public void onLightChange(Light light, long timestampMs) {
+        if (light == Light.GREEN) {
+            ultimoVerdeMs = timestampMs;
+        }
+    }
+
+    public AttemptResult registrarIntento(long timestampMs, Light currentLight) {
+        if (currentLight == Light.GREEN && ultimoVerdeMs != null) {
+            long diferencia = Math.max(0, timestampMs - ultimoVerdeMs);
+            long puntos = calcularPuntaje(diferencia);
+            aciertos++;
+            puntajeTotal += puntos;
+            return new AttemptResult(true, diferencia, puntos, aciertos, errores, puntajeTotal,
+                    "¡Acierto! Reacción: " + diferencia + " ms (+" + puntos + ")");
+        }
+
+        errores++;
+        return new AttemptResult(false, null, 0, aciertos, errores, puntajeTotal,
+                "No era verde. Espera la siguiente.");
+    }
+
+    /**
+     * Función pura de puntaje: solo depende del tiempo de reacción y no lee ni
+     * modifica estado interno.
+     */
+    public long calcularPuntaje(long diferenciaMs) {
+        long ventana = Math.max(0, 2000 - diferenciaMs);
+        return ventana / 5;
+    }
+
+    public int getAciertos() {
+        return aciertos;
+    }
+
+    public int getErrores() {
+        return errores;
+    }
+
+    public long getPuntajeTotal() {
+        return puntajeTotal;
+    }
+
+    public record AttemptResult(boolean acierto, Long reaccionMs, long puntos, int aciertos,
+                                int errores, long puntajeTotal, String mensaje) {
+    }
+}

--- a/SemaforoJavaFX/src/main/java/com/example/semaforo/Light.java
+++ b/SemaforoJavaFX/src/main/java/com/example/semaforo/Light.java
@@ -1,0 +1,10 @@
+package com.example.semaforo;
+
+/**
+ * Estados posibles del semáforo.
+ */
+public enum Light {
+    RED,
+    GREEN,
+    YELLOW
+}

--- a/SemaforoJavaFX/src/main/java/com/example/semaforo/LightRules.java
+++ b/SemaforoJavaFX/src/main/java/com/example/semaforo/LightRules.java
@@ -1,0 +1,50 @@
+package com.example.semaforo;
+
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Reglas declarativas (estilo programación lógica) para evaluar acciones
+ * permitidas o no según el color de la luz.
+ */
+public class LightRules {
+
+    private final Map<Light, Map<String, String>> reglas = new EnumMap<>(Light.class);
+
+    public LightRules() {
+        Map<String, String> rojo = new HashMap<>();
+        rojo.put("avanzar", "Infracción");
+        rojo.put("detenerse", "Correcto");
+
+        Map<String, String> verde = new HashMap<>();
+        verde.put("avanzar", "Permitido");
+        verde.put("detenerse", "Puedes avanzar con seguridad");
+
+        Map<String, String> amarillo = new HashMap<>();
+        amarillo.put("avanzar", "Precaución");
+        amarillo.put("detenerse", "Recomendado");
+
+        reglas.put(Light.RED, Map.copyOf(rojo));
+        reglas.put(Light.GREEN, Map.copyOf(verde));
+        reglas.put(Light.YELLOW, Map.copyOf(amarillo));
+    }
+
+    public String evaluarAccion(Light luz, String accion) {
+        if (accion == null) {
+            return "Sin regla definida";
+        }
+        String normalizada = accion.trim().toLowerCase(Locale.ROOT);
+        if (normalizada.isEmpty()) {
+            return "Sin regla definida";
+        }
+        return reglas.getOrDefault(luz, Collections.emptyMap())
+                .getOrDefault(normalizada, "Sin regla definida");
+    }
+
+    public Map<Light, Map<String, String>> getReglas() {
+        return Collections.unmodifiableMap(reglas);
+    }
+}

--- a/SemaforoJavaFX/src/main/java/com/example/semaforo/TrafficLightApp.java
+++ b/SemaforoJavaFX/src/main/java/com/example/semaforo/TrafficLightApp.java
@@ -1,0 +1,291 @@
+package com.example.semaforo;
+
+import javafx.animation.Animation;
+import javafx.animation.KeyFrame;
+import javafx.animation.Timeline;
+import javafx.application.Application;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.control.Slider;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.VBox;
+import javafx.scene.paint.Color;
+import javafx.scene.shape.Circle;
+import javafx.stage.Stage;
+import javafx.util.Duration;
+
+import java.util.Objects;
+
+public class TrafficLightApp extends Application {
+
+    private final TrafficLightLogic trafficLightLogic = new TrafficLightLogic();
+    private final GameLogic gameLogic = new GameLogic();
+    private final LightRules lightRules = new LightRules();
+
+    private Light currentLight = Light.RED;
+    private Timeline timeline;
+
+    private Circle redCircle;
+    private Circle yellowCircle;
+    private Circle greenCircle;
+    private Slider durationSlider;
+    private Label stateLabel;
+    private Label statusLabel;
+    private Label aciertosLabel;
+    private Label erroresLabel;
+    private Label puntajeLabel;
+    private Label reglaLabel;
+    private Label juegoLabel;
+    private TextField accionInput;
+
+    public static void main(String[] args) {
+        launch(args);
+    }
+
+    @Override
+    public void start(Stage stage) {
+        redCircle = createLightCircle(Color.web("#d7263d"));
+        yellowCircle = createLightCircle(Color.web("#f6c667"));
+        greenCircle = createLightCircle(Color.web("#26c281"));
+
+        durationSlider = createDurationSlider();
+        Label sliderLabel = new Label();
+        sliderLabel.getStyleClass().add("accent-text");
+        sliderLabel.textProperty().bind(durationSlider.valueProperty().asString("Segundos por luz: %.1f"));
+
+        HBox controlButtons = createControls();
+        VBox trafficLightBox = createTrafficLightBox();
+
+        VBox simulationPanel = new VBox(12,
+                titledLabel("Simulación"),
+                trafficLightBox,
+                sliderLabel,
+                durationSlider,
+                controlButtons,
+                buildStatusRow());
+        simulationPanel.getStyleClass().add("panel");
+
+        VBox gamePanel = createGamePanel();
+        VBox logicPanel = createLogicPanel();
+
+        HBox content = new HBox(18, simulationPanel, gamePanel);
+        content.setAlignment(Pos.TOP_CENTER);
+
+        VBox root = new VBox(18, titledLabel("Simulador de Semáforo"), content, logicPanel);
+        root.setAlignment(Pos.TOP_CENTER);
+        root.setPadding(new Insets(20));
+
+        Scene scene = new Scene(root, 960, 560);
+        scene.setFill(Color.web("#0f1116"));
+        scene.getStylesheets().add(Objects.requireNonNull(getClass().getResource("/style.css")).toExternalForm());
+
+        stage.setTitle("Simulador de Semáforo");
+        stage.setScene(scene);
+        stage.show();
+
+        configureTimeline();
+        updateLightColors();
+        updateStatus();
+        updateScoreLabels();
+    }
+
+    private VBox createTrafficLightBox() {
+        VBox lights = new VBox(12, redCircle, yellowCircle, greenCircle);
+        lights.setAlignment(Pos.CENTER);
+
+        VBox container = new VBox(lights);
+        container.setAlignment(Pos.CENTER);
+        container.setPadding(new Insets(16));
+        container.getStyleClass().add("traffic-box");
+        return container;
+    }
+
+    private VBox createGamePanel() {
+        Button reactionButton = new Button("¡YA!");
+        reactionButton.getStyleClass().add("primary-button");
+        reactionButton.setOnAction(event -> registrarIntento());
+
+        juegoLabel = new Label("Pulsa cuando la luz se ponga en verde.");
+        aciertosLabel = new Label();
+        erroresLabel = new Label();
+        puntajeLabel = new Label();
+
+        VBox gamePanel = new VBox(10,
+                titledLabel("Modo Juego"),
+                juegoLabel,
+                reactionButton,
+                aciertosLabel,
+                erroresLabel,
+                puntajeLabel);
+        gamePanel.getStyleClass().add("panel");
+        gamePanel.setAlignment(Pos.TOP_CENTER);
+        return gamePanel;
+    }
+
+    private VBox createLogicPanel() {
+        accionInput = new TextField("avanzar");
+        Button evaluarButton = new Button("Evaluar acción");
+        evaluarButton.setOnAction(event -> actualizarRegla());
+        reglaLabel = new Label();
+
+        HBox accionBox = new HBox(8, new Label("Acción:"), accionInput, evaluarButton);
+        accionBox.setAlignment(Pos.CENTER_LEFT);
+
+        VBox logicPanel = new VBox(10,
+                titledLabel("Programación lógica"),
+                new Label("Reglas: rojo/avanzar → Infracción, verde/avanzar → Permitido, amarillo/avanzar → Precaución"),
+                accionBox,
+                reglaLabel);
+        logicPanel.getStyleClass().add("panel");
+        logicPanel.setAlignment(Pos.CENTER_LEFT);
+        return logicPanel;
+    }
+
+    private HBox buildStatusRow() {
+        stateLabel = new Label();
+        statusLabel = new Label();
+        HBox statusRow = new HBox(10, stateLabel, statusLabel);
+        statusRow.setAlignment(Pos.CENTER);
+        return statusRow;
+    }
+
+    private HBox createControls() {
+        Button startButton = new Button("Iniciar");
+        startButton.getStyleClass().add("primary-button");
+        Button pauseButton = new Button("Pausar");
+        Button resumeButton = new Button("Reanudar");
+
+        startButton.setOnAction(event -> startTimeline());
+        pauseButton.setOnAction(event -> {
+            if (timeline != null) {
+                timeline.pause();
+            }
+        });
+        resumeButton.setOnAction(event -> {
+            if (timeline != null) {
+                timeline.play();
+            }
+        });
+
+        HBox controls = new HBox(10, startButton, pauseButton, resumeButton);
+        controls.setAlignment(Pos.CENTER);
+        return controls;
+    }
+
+    private void configureTimeline() {
+        timeline = createTimeline(durationSlider.getValue());
+    }
+
+    private Timeline createTimeline(double secondsPerState) {
+        KeyFrame frame = new KeyFrame(Duration.seconds(secondsPerState), event -> {
+            currentLight = trafficLightLogic.nextState(currentLight);
+            gameLogic.onLightChange(currentLight, System.currentTimeMillis());
+            updateLightColors();
+            updateStatus();
+            actualizarRegla();
+        });
+
+        Timeline newTimeline = new Timeline(frame);
+        newTimeline.setCycleCount(Animation.INDEFINITE);
+        return newTimeline;
+    }
+
+    private void rebuildTimelineWithDuration(double secondsPerState) {
+        Animation.Status previousStatus = timeline != null ? timeline.getStatus() : Animation.Status.STOPPED;
+        if (timeline != null) {
+            timeline.stop();
+        }
+        timeline = createTimeline(secondsPerState);
+
+        if (previousStatus == Animation.Status.RUNNING) {
+            timeline.play();
+        } else if (previousStatus == Animation.Status.PAUSED) {
+            timeline.pause();
+        }
+    }
+
+    private void startTimeline() {
+        if (timeline == null) {
+            configureTimeline();
+        }
+        currentLight = Light.RED;
+        gameLogic.reset();
+        updateLightColors();
+        updateStatus();
+        actualizarRegla();
+        updateScoreLabels();
+        timeline.playFromStart();
+    }
+
+    private void registrarIntento() {
+        GameLogic.AttemptResult result = gameLogic.registrarIntento(System.currentTimeMillis(), currentLight);
+        juegoLabel.setText(result.mensaje());
+        updateScoreLabels();
+    }
+
+    private Slider createDurationSlider() {
+        Slider slider = new Slider(1, 10, 3);
+        slider.setShowTickLabels(true);
+        slider.setShowTickMarks(true);
+        slider.setMajorTickUnit(1);
+        slider.setBlockIncrement(0.5);
+        slider.valueProperty().addListener((obs, oldVal, newVal) -> rebuildTimelineWithDuration(newVal.doubleValue()));
+        return slider;
+    }
+
+    private Circle createLightCircle(Color activeColor) {
+        Circle circle = new Circle(45);
+        circle.getStyleClass().add("traffic-light");
+        circle.setStroke(Color.web("#0d0f14"));
+        circle.setStrokeWidth(3);
+        circle.setUserData(activeColor);
+        circle.setFill(dimColor(activeColor));
+        return circle;
+    }
+
+    private void updateLightColors() {
+        setCircleState(redCircle, currentLight == Light.RED);
+        setCircleState(yellowCircle, currentLight == Light.YELLOW);
+        setCircleState(greenCircle, currentLight == Light.GREEN);
+    }
+
+    private void setCircleState(Circle circle, boolean active) {
+        Color base = (Color) circle.getUserData();
+        circle.setFill(active ? base : dimColor(base));
+    }
+
+    private Color dimColor(Color color) {
+        return color.darker().darker();
+    }
+
+    private void updateStatus() {
+        stateLabel.setText("Estado: " + currentLight);
+        switch (currentLight) {
+            case GREEN -> statusLabel.setText("¡Es verde! Puedes avanzar.");
+            case YELLOW -> statusLabel.setText("Amarillo: precaución.");
+            case RED -> statusLabel.setText("Rojo: detente.");
+        }
+    }
+
+    private void updateScoreLabels() {
+        aciertosLabel.setText("Aciertos: " + gameLogic.getAciertos());
+        erroresLabel.setText("Errores: " + gameLogic.getErrores());
+        puntajeLabel.setText("Puntaje: " + gameLogic.getPuntajeTotal());
+    }
+
+    private void actualizarRegla() {
+        String accion = accionInput.getText();
+        String resultado = lightRules.evaluarAccion(currentLight, accion);
+        reglaLabel.setText("Resultado acción '" + accion + "' con luz " + currentLight + ": " + resultado);
+    }
+
+    private Label titledLabel(String text) {
+        Label label = new Label(text);
+        label.getStyleClass().add("heading");
+        return label;
+    }
+}

--- a/SemaforoJavaFX/src/main/java/com/example/semaforo/TrafficLightLogic.java
+++ b/SemaforoJavaFX/src/main/java/com/example/semaforo/TrafficLightLogic.java
@@ -1,0 +1,25 @@
+package com.example.semaforo;
+
+import java.util.function.UnaryOperator;
+
+/**
+ * Lógica funcional del semáforo. La función {@link #nextState(Light)} es pura
+ * porque para una entrada dada (el estado actual) siempre devuelve el mismo
+ * resultado, sin modificar estado interno ni depender de variables externas.
+ */
+public class TrafficLightLogic {
+
+    private final UnaryOperator<Light> nextStateFunction = light -> switch (light) {
+        case RED -> Light.GREEN;
+        case GREEN -> Light.YELLOW;
+        case YELLOW -> Light.RED;
+    };
+
+    public Light nextState(Light actual) {
+        return nextStateFunction.apply(actual);
+    }
+
+    public UnaryOperator<Light> getNextStateFunction() {
+        return nextStateFunction;
+    }
+}

--- a/SemaforoJavaFX/src/main/resources/style.css
+++ b/SemaforoJavaFX/src/main/resources/style.css
@@ -1,0 +1,62 @@
+.root {
+    -fx-background-color: #0f1116;
+    -fx-font-family: 'Segoe UI', 'Roboto', 'Helvetica', sans-serif;
+    -fx-text-fill: #f8f9fb;
+}
+
+.panel {
+   -fx-background-color: rgba(255,255,255,0.04);
+   -fx-border-color: rgba(255,255,255,0.12);
+   -fx-border-radius: 12;
+   -fx-background-radius: 12;
+   -fx-padding: 16;
+   -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.35), 16, 0.3, 0, 6);
+}
+
+.traffic-box {
+    -fx-background-color: linear-gradient(#1b1f2b, #141824);
+    -fx-border-color: #3a4257;
+    -fx-border-radius: 18;
+    -fx-background-radius: 18;
+    -fx-padding: 18;
+    -fx-effect: innershadow(gaussian, rgba(0,0,0,0.55), 10, 0.3, 0, 2);
+}
+
+.traffic-light {
+    -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.45), 10, 0.3, 0, 3);
+}
+
+.heading {
+    -fx-font-size: 20px;
+    -fx-font-weight: bold;
+    -fx-text-fill: #f8f9fb;
+}
+
+.accent-text {
+    -fx-text-fill: #9ac9ff;
+}
+
+.button {
+    -fx-background-radius: 10;
+    -fx-padding: 8 14;
+    -fx-font-weight: bold;
+}
+
+.primary-button {
+    -fx-background-color: linear-gradient(#4f8af7, #1c6ce5);
+    -fx-text-fill: white;
+    -fx-border-color: rgba(255,255,255,0.2);
+    -fx-border-radius: 10;
+}
+
+.label {
+    -fx-text-fill: #dfe4ed;
+}
+
+.slider .track {
+    -fx-background-color: #2b3040;
+}
+
+.slider .thumb {
+    -fx-background-color: #4f8af7;
+}


### PR DESCRIPTION
## Summary
- rebuild SemaforoJavaFX as a Maven JavaFX app with dark-styled UI, timeline controls, and reaction game mode
- add functional logic helpers for state transitions and scoring plus declarative LightRules evaluation
- document build/run steps and styling resources for the simulator

## Testing
- mvn -f SemaforoJavaFX/pom.xml -DskipTests package *(fails: Maven Central 403 Forbidden while downloading maven-resources-plugin)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925364bcf788324aecf6287802361b0)